### PR TITLE
chore(infra): higiene de segredos e configuração por ambiente (F0-T1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,40 @@
+# ---- Segredos e ambiente ----
+.env
+.env.*
+!.env.example
+*.pem
+*.key
+
+# ---- Python ----
+__pycache__/
+*.py[cod]
+*$py.class
+*.egg-info/
+build/
+dist/
+.Python
+
+# ---- Ambientes virtuais ----
+.venv/
+venv/
+env/
+ENV/
+
+# ---- Testes e cobertura ----
+.pytest_cache/
+.coverage
+.coverage.*
+htmlcov/
+.ruff_cache/
+.mypy_cache/
+
+# ---- Editores e SO ----
+.vscode/
+.idea/
+*.swp
+.DS_Store
+Thumbs.db
+
+# ---- Logs e dumps locais ----
+*.log
+*.sqlite3

--- a/FichaAnamnese_api/.env.example
+++ b/FichaAnamnese_api/.env.example
@@ -1,0 +1,20 @@
+# Copie este arquivo para `.env` e preencha com valores REAIS.
+# O `.env` é ignorado pelo git — nunca versione segredos.
+#
+# Gerar senhas fortes e URL-safe (evita quebrar a DATABASE_URL):
+#   python3 -c "import secrets; print(secrets.token_urlsafe(24))"
+
+# ---- Postgres (container `db`) ----
+POSTGRES_USER=
+POSTGRES_PASSWORD=
+POSTGRES_DB=fichas_anamnese_bd
+
+# ---- API ----
+# Host `db` = nome do serviço no docker-compose. Fora do compose, use `localhost:5433`.
+# Se a senha tiver caracteres especiais (@ # : / ?), faça URL-encode dela:
+#   python3 -c "from urllib.parse import quote; print(quote(input(), safe=''))"
+DATABASE_URL=postgresql+psycopg2://<POSTGRES_USER>:<POSTGRES_PASSWORD>@db:5432/<POSTGRES_DB>
+
+# ---- pgAdmin ----
+PGADMIN_DEFAULT_EMAIL=
+PGADMIN_DEFAULT_PASSWORD=

--- a/FichaAnamnese_api/docker-compose.yml
+++ b/FichaAnamnese_api/docker-compose.yml
@@ -3,8 +3,10 @@ services:
     build: .
     ports:
       - "8000:8000"
-    env_file:
-      - .env
+    # Sem `env_file`: a API recebe só o que precisa, e não as senhas do
+    # Postgres/pgAdmin. Novas variáveis da API entram explicitamente aqui.
+    environment:
+      DATABASE_URL: ${DATABASE_URL:?defina DATABASE_URL no .env}
     depends_on:
       db:
         condition: service_healthy
@@ -12,14 +14,12 @@ services:
 
   db:
     image: postgres:16-alpine
-    env_file:
-      - .env
     ports:
       - "5433:5432"
     environment:
-      POSTGRES_USER: ${POSTGRES_USER}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
-      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_USER: ${POSTGRES_USER:?defina POSTGRES_USER no .env}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?defina POSTGRES_PASSWORD no .env}
+      POSTGRES_DB: ${POSTGRES_DB:?defina POSTGRES_DB no .env}
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:
@@ -32,11 +32,12 @@ services:
     image: dpage/pgadmin4
     ports:
       - "5050:80"
-    env_file:
-      - .env
     environment:
-      PGADMIN_DEFAULT_EMAIL: ${PGADMIN_DEFAULT_EMAIL}
-      PGADMIN_DEFAULT_PASSWORD: ${PGADMIN_DEFAULT_PASSWORD}
+      PGADMIN_DEFAULT_EMAIL: ${PGADMIN_DEFAULT_EMAIL:?defina PGADMIN_DEFAULT_EMAIL no .env}
+      PGADMIN_DEFAULT_PASSWORD: ${PGADMIN_DEFAULT_PASSWORD:?defina PGADMIN_DEFAULT_PASSWORD no .env}
+    depends_on:
+      db:
+        condition: service_healthy
 
 volumes:
   postgres_data:

--- a/FichaAnamnese_api/tests/test_secrets_hygiene.py
+++ b/FichaAnamnese_api/tests/test_secrets_hygiene.py
@@ -1,0 +1,253 @@
+"""Testes de higiene de segredos (F0-T1).
+
+Garantem que o repositório não volte a versionar credenciais e que o
+`docker-compose.yml` seja resolvível apenas a partir do `.env`.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+# Chaves cujo valor NUNCA pode aparecer literal em arquivo versionado.
+CHAVES_SECRETAS = (
+    "POSTGRES_PASSWORD",
+    "PGADMIN_DEFAULT_PASSWORD",
+    "JWT_SECRET",
+    "SECRET_KEY",
+    "AWS_SECRET_ACCESS_KEY",
+    "R2_SECRET_ACCESS_KEY",
+)
+
+# Valor aceito para uma chave secreta: vazio, `${VAR}`, `$VAR` ou `<PLACEHOLDER>`.
+_VALOR_SEGURO = re.compile(r"^(\$\{[^}]+\}|\$[A-Z_][A-Z0-9_]*|<[^>]+>)$")
+
+# `[ \t]*` (e não `\s*`) para o valor nunca vazar para a linha seguinte.
+_ATRIBUICAO = re.compile(
+    r"^[ \t]*-?[ \t]*(?P<chave>"
+    + "|".join(CHAVES_SECRETAS)
+    + r")[ \t]*[:=][ \t]*(?P<valor>[^\n]*?)[ \t]*$",
+    re.MULTILINE,
+)
+
+# URL de conexão com credencial embutida: postgresql://user:senha@host/db
+_URL_COM_CREDENCIAL = re.compile(
+    r"(?P<esquema>[a-z][a-z0-9+.\-]*)://(?P<user>[^\s:/@]+):(?P<senha>[^\s@/]+)@",
+)
+
+# SHA-256 dos segredos sabidamente comprometidos (o valor em si não é versionado).
+DIGESTS_COMPROMETIDOS = {
+    "f09ab5e40ec95c5a19bbf321b8ed5f48ce40c3735884be56394898605a672a95": (
+        "senha do Postgres exposta no docker-compose.yml (histórico público)"
+    ),
+}
+
+_SEPARADORES = "`\"'(),.;*[]{}"
+
+
+def _repo_root() -> Path:
+    saida = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        cwd=Path(__file__).resolve().parent,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return Path(saida.stdout.strip())
+
+
+REPO = _repo_root()
+API_DIR = Path(__file__).resolve().parent.parent
+
+
+def _arquivos_versionados() -> list[Path]:
+    saida = subprocess.run(
+        ["git", "ls-files", "-z"],
+        cwd=REPO,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return [REPO / nome for nome in saida.stdout.split("\0") if nome]
+
+
+def violacoes_de_padrao(texto: str) -> list[str]:
+    """Retorna descrições de credenciais literais encontradas em `texto`."""
+    achados: list[str] = []
+
+    for m in _ATRIBUICAO.finditer(texto):
+        valor = m.group("valor")
+        if valor and not _VALOR_SEGURO.match(valor):
+            achados.append(f"{m.group('chave')} com valor literal")
+
+    for m in _URL_COM_CREDENCIAL.finditer(texto):
+        senha = m.group("senha")
+        if not _VALOR_SEGURO.match(senha):
+            achados.append(f"URL {m.group('esquema')}:// com senha embutida")
+
+    return achados
+
+
+def tokens_comprometidos(texto: str) -> list[str]:
+    """Retorna a descrição de cada segredo comprometido presente em `texto`."""
+    achados: list[str] = []
+    for bruto in texto.split():
+        token = bruto.strip(_SEPARADORES)
+        if not token:
+            continue
+        digest = hashlib.sha256(token.encode("utf-8")).hexdigest()
+        if digest in DIGESTS_COMPROMETIDOS:
+            achados.append(DIGESTS_COMPROMETIDOS[digest])
+    return achados
+
+
+def _ler(caminho: Path) -> str | None:
+    try:
+        return caminho.read_text(encoding="utf-8")
+    except (UnicodeDecodeError, OSError):
+        return None
+
+
+# --------------------------------------------------------------------------
+# Caminho feliz: o repositório está limpo
+# --------------------------------------------------------------------------
+
+
+def test_nenhum_segredo_literal_em_arquivo_versionado() -> None:
+    problemas: list[str] = []
+    for arquivo in _arquivos_versionados():
+        texto = _ler(arquivo)
+        if texto is None:
+            continue
+        rel = arquivo.relative_to(REPO)
+        problemas += [f"{rel}: {v}" for v in violacoes_de_padrao(texto)]
+        problemas += [f"{rel}: {v}" for v in tokens_comprometidos(texto)]
+
+    assert not problemas, "Segredos literais versionados:\n" + "\n".join(problemas)
+
+
+def test_env_e_ignorado_e_env_example_nao() -> None:
+    def ignorado(caminho: str) -> bool:
+        return (
+            subprocess.run(
+                ["git", "check-ignore", "-q", caminho], cwd=REPO, check=False
+            ).returncode
+            == 0
+        )
+
+    assert ignorado("FichaAnamnese_api/.env"), ".env precisa estar no .gitignore"
+    assert not ignorado(
+        "FichaAnamnese_api/.env.example"
+    ), ".env.example deve continuar versionado"
+
+
+def test_env_nao_esta_versionado() -> None:
+    versionados = {p.name for p in _arquivos_versionados()}
+    assert ".env" not in versionados
+
+
+def test_env_example_declara_todas_as_variaveis_do_compose() -> None:
+    compose = (API_DIR / "docker-compose.yml").read_text(encoding="utf-8")
+    exemplo = (API_DIR / ".env.example").read_text(encoding="utf-8")
+
+    usadas = set(re.findall(r"\$\{([A-Z_][A-Z0-9_]*)", compose))
+    declaradas = set(re.findall(r"^([A-Z_][A-Z0-9_]*)=", exemplo, re.MULTILINE))
+
+    faltando = usadas - declaradas
+    assert not faltando, f"Variáveis sem entrada no .env.example: {sorted(faltando)}"
+
+
+def test_env_example_nao_traz_valores_secretos() -> None:
+    exemplo = (API_DIR / ".env.example").read_text(encoding="utf-8")
+    assert not violacoes_de_padrao(exemplo)
+
+
+# --------------------------------------------------------------------------
+# Caminho de erro: o guarda precisa reprovar conteúdo sujo
+# --------------------------------------------------------------------------
+
+
+def test_scanner_reprova_senha_literal() -> None:
+    sujo = "    POSTGRES_PASSWORD: super-secreta-123\n"
+    assert violacoes_de_padrao(sujo) == ["POSTGRES_PASSWORD com valor literal"]
+
+
+def test_scanner_reprova_url_com_credencial() -> None:
+    sujo = "DATABASE_URL=postgresql://becadev:umaSenhaQualquer@db:5432/fichas\n"
+    assert violacoes_de_padrao(sujo) == ["URL postgresql:// com senha embutida"]
+
+
+def test_scanner_aceita_interpolacao_e_placeholder() -> None:
+    limpo = (
+        "POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}\n"
+        "PGADMIN_DEFAULT_PASSWORD=\n"
+        "DATABASE_URL=postgresql+psycopg2://<POSTGRES_USER>:<POSTGRES_PASSWORD>@db:5432/x\n"
+    )
+    assert violacoes_de_padrao(limpo) == []
+
+
+def test_scanner_detecta_segredo_comprometido_por_hash() -> None:
+    (digest,) = DIGESTS_COMPROMETIDOS
+    assert len(digest) == 64
+    assert tokens_comprometidos("nada suspeito por aqui") == []
+
+
+# --------------------------------------------------------------------------
+# `docker compose config` resolve o .env (e falha sem ele)
+# --------------------------------------------------------------------------
+
+_sem_docker = pytest.mark.skipif(
+    shutil.which("docker") is None, reason="docker não disponível"
+)
+
+
+def _compose_config(env_file: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["docker", "compose", "--env-file", str(env_file), "config"],
+        cwd=API_DIR,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+@_sem_docker
+def test_compose_config_resolve_variaveis(tmp_path: Path) -> None:
+    env = tmp_path / "env"
+    env.write_text(
+        "POSTGRES_USER=usuario_teste\n"
+        "POSTGRES_PASSWORD=senha_de_teste\n"
+        "POSTGRES_DB=banco_teste\n"
+        "PGADMIN_DEFAULT_EMAIL=teste@example.com\n"
+        "PGADMIN_DEFAULT_PASSWORD=pgadmin_de_teste\n"
+        "DATABASE_URL=postgresql+psycopg2://usuario_teste:senha_de_teste@db:5432/banco_teste\n",
+        encoding="utf-8",
+    )
+
+    resultado = _compose_config(env)
+
+    assert resultado.returncode == 0, resultado.stderr
+    assert "usuario_teste" in resultado.stdout
+    assert "${" not in resultado.stdout
+
+
+@_sem_docker
+def test_compose_config_falha_sem_variavel_obrigatoria(tmp_path: Path) -> None:
+    env = tmp_path / "env"
+    env.write_text("POSTGRES_USER=usuario_teste\n", encoding="utf-8")
+
+    resultado = _compose_config(env)
+
+    assert resultado.returncode != 0
+    # O compose aborta na primeira variável obrigatória que faltar; qual delas
+    # é reportada varia com a ordem de avaliação dos serviços.
+    assert "required variable" in resultado.stderr
+    assert any(
+        var in resultado.stderr
+        for var in ("POSTGRES_PASSWORD", "POSTGRES_DB", "PGADMIN_DEFAULT_")
+    ), resultado.stderr

--- a/FichaAnamnese_api/tests/test_secrets_hygiene.py
+++ b/FichaAnamnese_api/tests/test_secrets_hygiene.py
@@ -119,13 +119,18 @@ def _ler(caminho: Path) -> str | None:
 
 
 def test_nenhum_segredo_literal_em_arquivo_versionado() -> None:
+    este_arquivo = Path(__file__).resolve()
+
     problemas: list[str] = []
     for arquivo in _arquivos_versionados():
         texto = _ler(arquivo)
         if texto is None:
             continue
         rel = arquivo.relative_to(REPO)
-        problemas += [f"{rel}: {v}" for v in violacoes_de_padrao(texto)]
+        # Este módulo carrega credenciais FALSAS de propósito (fixtures dos
+        # testes de erro); só a checagem por hash faz sentido nele.
+        if arquivo.resolve() != este_arquivo:
+            problemas += [f"{rel}: {v}" for v in violacoes_de_padrao(texto)]
         problemas += [f"{rel}: {v}" for v in tokens_comprometidos(texto)]
 
     assert not problemas, "Segredos literais versionados:\n" + "\n".join(problemas)
@@ -247,7 +252,7 @@ def test_compose_config_falha_sem_variavel_obrigatoria(tmp_path: Path) -> None:
     # O compose aborta na primeira variável obrigatória que faltar; qual delas
     # é reportada varia com a ordem de avaliação dos serviços.
     assert "required variable" in resultado.stderr
-    assert any(
-        var in resultado.stderr
-        for var in ("POSTGRES_PASSWORD", "POSTGRES_DB", "PGADMIN_DEFAULT_")
-    ), resultado.stderr
+    compose = (API_DIR / "docker-compose.yml").read_text(encoding="utf-8")
+    obrigatorias = set(re.findall(r"\$\{([A-Z_][A-Z0-9_]*):\?", compose))
+    assert obrigatorias, "o compose deveria marcar variáveis com `${VAR:?}`"
+    assert any(var in resultado.stderr for var in obrigatorias), resultado.stderr

--- a/PLANEJAMENTO.md
+++ b/PLANEJAMENTO.md
@@ -16,8 +16,8 @@
 ### 1.2. Problemas que precisam ser corrigidos antes de evoluir
 
 **🔴 Segurança (urgente)**
-- O `docker-compose.yml` versiona **senha do banco em texto puro** (`bd!Q@W#E$R1`) e a senha do pgAdmin (`admin`). Como o repositório ficou público, **considere esses segredos comprometidos**: gere novas senhas e nunca mais as versione (use `.env` + `.gitignore`).
-- Essa mesma senha tem caracteres especiais (`!@#$`) que **quebram a `DATABASE_URL`** sem URL-encoding (`@` e `#` são delimitadores de URL).
+- O `docker-compose.yml` versionava **senha do banco em texto puro** e a senha do pgAdmin (valores omitidos aqui de propósito — veja o histórico do git). Como o repositório ficou público, **considere esses segredos comprometidos**: gere novas senhas e nunca mais as versione (use `.env` + `.gitignore`). *(Tratado em F0-T1.)*
+- Essa mesma senha tinha caracteres especiais (`!@#$`) que **quebram a `DATABASE_URL`** sem URL-encoding (`@` e `#` são delimitadores de URL).
 
 **🔴 A API não sobe hoje (imports quebrados)**
 - `app/models.py`: `from ..app.modules.fichas.models import ...` — caminho relativo inválido.

--- a/README.md
+++ b/README.md
@@ -1,13 +1,71 @@
 # FichaAnamnese
-Aplicação para criar fichas de Anamnese para estética
 
+Aplicação para criar fichas de Anamnese para estética.
 
 - [Frontend](https://github.com/becadev/FichaAnamnese-Frontend)
 
+## Configuração de ambiente
 
+Nenhum segredo é versionado. Toda credencial vive no `.env` (ignorado pelo git);
+o `.env.example` documenta as chaves esperadas, sem valores.
 
+```bash
+cd FichaAnamnese_api
+cp .env.example .env
+chmod 600 .env
+```
 
-Como rodar:
+Gere senhas fortes e **URL-safe** (evita quebrar a `DATABASE_URL`, onde `@` e `#`
+são delimitadores):
+
+```bash
+python3 -c "import secrets; print(secrets.token_urlsafe(24))"
+```
+
+Preencha `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_DB`,
+`PGADMIN_DEFAULT_EMAIL`, `PGADMIN_DEFAULT_PASSWORD` e monte a `DATABASE_URL` com
+os mesmos valores. Se a senha tiver caracteres especiais, faça URL-encode dela:
+
+```bash
+python3 -c "from urllib.parse import quote; print(quote(input(), safe=''))"
+```
+
+Confira que tudo foi resolvido antes de subir:
+
+```bash
+docker compose config
+```
+
+## Como rodar
+
+```bash
+cd FichaAnamnese_api
 docker compose up -d --build
-docker run -p 8000:8000 fichaanamnese_api
-docker compose ps (ver se os containers foram criados - bd, api e pgadmin)
+docker compose ps   # db, api e pgadmin
+```
+
+- API: <http://localhost:8000>
+- pgAdmin: <http://localhost:5050>
+- Postgres: `localhost:5433`
+
+## Rotação de credenciais
+
+As credenciais anteriores foram expostas em commits públicos e estão
+**comprometidas**. Ao trocar `POSTGRES_USER`/`POSTGRES_PASSWORD`, o volume
+existente ainda guarda a senha antiga — recrie-o:
+
+```bash
+docker compose down -v   # apaga o volume postgres_data
+docker compose up -d --build
+```
+
+> O histórico do git ainda contém os valores antigos. Reescrever o histórico
+> (`git filter-repo`) é opcional; o essencial é que as senhas antigas não sejam
+> mais válidas em lugar nenhum.
+
+## Testes
+
+```bash
+python3 -m venv .venv && .venv/bin/pip install pytest
+.venv/bin/pytest FichaAnamnese_api/tests
+```


### PR DESCRIPTION
## chore(infra): higiene de segredos e configuração por ambiente (F0-T1)

Remove credenciais literais do repositório e padroniza a configuração por ambiente.

### Mudanças
- `.gitignore` na raiz (`.env`, `__pycache__`, `.venv`, caches)
- `.env.example` com as chaves sem valores + instruções de geração e URL-encode
- `docker-compose.yml`: `${VAR:?msg}` para variáveis obrigatórias; `env_file`
  removido de `db`/`pgadmin`; `api` recebe apenas `DATABASE_URL` (least privilege)
- `PLANEJAMENTO.md`: senha exposta no texto foi redigida
- `README.md`: setup do `.env`, `docker compose config` e rotação (`down -v`)
- `tests/test_secrets_hygiene.py`: guarda de regressão contra novos vazamentos

### Critérios de aceite
- [x] `git grep` não encontra senhas literais
- [x] `docker compose config` resolve as variáveis do `.env`
- [x] credenciais rotacionadas; `db`/`pgadmin` sobem com as novas (senha antiga inválida)
- [x] `ruff` + `black` limpos, `pytest` 11/11

### Notas
- **Sem migration** (task não toca schema).
- As senhas antigas seguem no histórico público: considere-as comprometidas.
  A rotação já as invalidou; reescrita de histórico (`git filter-repo`) fica a critério
  do time, pois exige force-push.
- A API ainda não sobe por causa do import circular em `app/models.py` — defeito
  pré-existente, escopo da **F0-T2**. Este PR valida `db` + `pgadmin`.
